### PR TITLE
Add feature to trigger channels independently based on MIDI channel

### DIFF
--- a/plugin/Source/PluginEditor.cpp
+++ b/plugin/Source/PluginEditor.cpp
@@ -103,6 +103,7 @@ void PAPUAudioProcessorEditor::resized()
     controls[n - 2]->setBounds (getGridArea (14, 3));
     controls[n - 3]->setBounds (getGridArea (11, 3));
     controls[n - 4]->setBounds (getGridArea (12, 3));
+    controls[n - 5]->setBounds (getGridArea (10, 3));
     
     scope.setBounds (getGridArea (10, 0, 5, 3).reduced (5));
 }

--- a/plugin/Source/PluginProcessor.cpp
+++ b/plugin/Source/PluginProcessor.cpp
@@ -402,8 +402,8 @@ juce::String intTextFunction (const gin::Parameter&, float v)
 //==============================================================================
 PAPUAudioProcessor::PAPUAudioProcessor()
 {
-    addExtParam (paramPulse1OL,    "Pulse 1 OL",        "Left",    "",  {    0.0f,   1.0f, 1.0f, 1.0f },    0.0f, 0.0f, enableTextFunction);
-    addExtParam (paramPulse1OR,    "Pulse 1 OR",        "Right",   "",  {    0.0f,   1.0f, 1.0f, 1.0f },    0.0f, 0.0f, enableTextFunction);
+    addExtParam (paramPulse1OL,    "Pulse 1 OL",        "Left",    "",  {    0.0f,   1.0f, 1.0f, 1.0f },    1.0f, 0.0f, enableTextFunction);
+    addExtParam (paramPulse1OR,    "Pulse 1 OR",        "Right",   "",  {    0.0f,   1.0f, 1.0f, 1.0f },    1.0f, 0.0f, enableTextFunction);
     addExtParam (paramPulse1Duty,  "Pulse 1 Duty",      "PW",      "",  {    0.0f,   3.0f, 1.0f, 1.0f },    0.0f, 0.0f, dutyTextFunction);
     addExtParam (paramPulse1A,     "Pulse 1 A",         "Attack",  "",  {    0.0f,   7.0f, 1.0f, 1.0f },    1.0f, 0.0f, arTextFunction);
     addExtParam (paramPulse1R,     "Pulse 1 R",         "Release", "",  {    0.0f,   7.0f, 1.0f, 1.0f },    1.0f, 0.0f, arTextFunction);
@@ -425,9 +425,9 @@ PAPUAudioProcessor::PAPUAudioProcessor()
     addExtParam (paramNoiseShift,  "Noise Shift",       "Shift",   "",  {    0.0f,  13.0f, 1.0f, 1.0f },    0.0f, 0.0f, intTextFunction);
     addExtParam (paramNoiseStep,   "Noise Step",        "Steps",   "",  {    0.0f,   1.0f, 1.0f, 1.0f },    0.0f, 0.0f, stepTextFunction);
     addExtParam (paramNoiseRatio,  "Noise Ratio",       "Ratio",   "",  {    0.0f,   7.0f, 1.0f, 1.0f },    0.0f, 0.0f, intTextFunction);
-    addExtParam (paramWaveOL,      "Wave OL",           "Left",    "",  {    0.0f,   1.0f, 1.0f, 1.0f },    1.0f, 0.0f, enableTextFunction);
-    addExtParam (paramWaveOR,      "Wave OR",           "Right",   "",  {    0.0f,   1.0f, 1.0f, 1.0f },    1.0f, 0.0f, enableTextFunction);
-    addExtParam (paramWaveWfm,     "Waveform",          "Waveform", "", {    0.0f,  14.0f, 1.0f, 1.0f },   0.0f, 0.0f, intTextFunction);
+    addExtParam (paramWaveOL,      "Wave OL",           "Left",    "",  {    0.0f,   1.0f, 1.0f, 1.0f },    0.0f, 0.0f, enableTextFunction);
+    addExtParam (paramWaveOR,      "Wave OR",           "Right",   "",  {    0.0f,   1.0f, 1.0f, 1.0f },    0.0f, 0.0f, enableTextFunction);
+    addExtParam (paramWaveWfm,     "Waveform",          "Waveform", "", {    0.0f,  14.0f, 1.0f, 1.0f },    0.0f, 0.0f, intTextFunction);
     addExtParam (paramWaveTune,    "Wave Tune",         "Tune",    "",  {  -48.0f,  48.0f, 1.0f, 1.0f },    0.0f, 0.0f, intTextFunction);
     addExtParam (paramWaveFine,    "Wave Tune Fine",    "Fine",    "",  { -100.0f, 100.0f, 1.0f, 1.0f },    0.0f, 0.0f, intTextFunction);
     addExtParam (paramTreble,      "Treble EQ",         "Treble",  "",  {  -50.0f,  50.0f, 1.0f, 1.0f },  -30.0f, 0.0f, intTextFunction);

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -74,6 +74,8 @@ public:
     gin::LFO vib3;
     int vibNote1, vibNote2, vibNote3;
     
+    bool channelsplit = false;
+    
 private:
     int parameterIntValue (const juce::String& uid);
     void runOscs (int curNote1, int curNote2, int curNote3, int curNote4, bool trigger1, bool trigger2, bool trigger3, bool trigger4);
@@ -161,6 +163,7 @@ public:
     static juce::String paramWaveFine;
     static juce::String paramWaveVibRate;
     static juce::String paramWaveVibAmt;
+    static juce::String paramChannelSplit;
     static juce::String paramTreble;
     static juce::String paramBass;
     static juce::String paramOutput;

--- a/plugin/Source/PluginProcessor.h
+++ b/plugin/Source/PluginProcessor.h
@@ -46,7 +46,18 @@ public:
     void handleMessage (const juce::MidiMessage& msg);
     void runUntil (int& done, juce::AudioSampleBuffer& buffer, int pos);
 
-    int getNote()   { return lastNote; }
+    int getNote(int note)
+    {
+        if (note == 1) {return lastNote1;}
+        else if (note == 2) {return lastNote2;}
+        else if (note == 3) {return lastNote3;}
+        else if (note == 4) {return lastNote4;}
+        else {return -1;}
+    }
+    int getNote1() { return lastNote1; }
+    int getNote2() { return lastNote2; }
+    int getNote3() { return lastNote3; }
+    int getNote4() { return lastNote4; }
 
     uint8_t waveIndex = 0;
     void setWave(uint8_t index);
@@ -61,17 +72,23 @@ public:
     gin::LFO vib1;
     gin::LFO vib2;
     gin::LFO vib3;
-    int vibNote;
+    int vibNote1, vibNote2, vibNote3;
     
 private:
     int parameterIntValue (const juce::String& uid);
-    void runOscs (int curNote, bool trigger);
+    void runOscs (int curNote1, int curNote2, int curNote3, int curNote4, bool trigger1, bool trigger2, bool trigger3, bool trigger4);
 
     PAPUAudioProcessor& processor;
 
-    int lastNote = -1;
+    int lastNote1 = -1;
+    int lastNote2 = -1;
+    int lastNote3 = -1;
+    int lastNote4 = -1;
     double pitchBend = 0;
-    juce::Array<int> noteQueue;
+    juce::Array<int> noteQueue1;
+    juce::Array<int> noteQueue2;
+    juce::Array<int> noteQueue3;
+    juce::Array<int> noteQueue4;
     float freq1 = 0.0f, freq2 = 0.0f, freq3 = 0.0f;
     
     void runVibrato(int todo);
@@ -157,8 +174,8 @@ public:
 
 private:
     void runUntil (int& done, juce::AudioSampleBuffer& buffer, int pos);
-    PAPUEngine* findFreeVoice();
-    PAPUEngine* findVoiceForNote (int note);
+    PAPUEngine* findFreeVoice(int channel);
+    PAPUEngine* findVoiceForNote (int note, int channel);
     
     juce::OwnedArray<PAPUEngine> papus;
     int nextVoice = 0;


### PR DESCRIPTION
When "Channel split" is on, MIDI channel 1 to 4 will trigger the APU channels respectively. It makes it possible to play a complete song using just one instance.

Makes the code a bit more complex but I think this feature is worth it.

I've made my best to ensure that voices are correctly shut when switching the MIDI channel split on and off.

I'll let you be the judge for better labelling of the new UI switch!