### PR TITLE
Consider using HTTPS links in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "modules/drowaudio"]
 	path = modules/dRowAudio
-	url = git@github.com:FigBug/drowaudio.git
+	url = https://github.com/FigBug/drowaudio.git
 [submodule "modules/gin"]
 	path = modules/gin
-	url = git@github.com:FigBug/Gin.git
+	url = https://github.com/FigBug/Gin.git
 [submodule "modules/juce"]
 	path = modules/juce
-	url = git@github.com:WeAreROLI/JUCE.git
+	url = https://github.com/WeAreROLI/JUCE.git
 [submodule "modules/plugin_sdk"]
 	path = modules/plugin_sdk
 	url = https://github.com/TurnipHat/plugin_sdk.git


### PR DESCRIPTION
This PR changes the SSH links in `.gitmodules` to HTTPS links. This allows to fully clone the repo without requiring a Github account or edit `.gitmodules`. This also makes it easier to package for Nix.